### PR TITLE
Add Flask questionnaire app for communication skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+responses.csv
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # metricas
 Fontes em python para análise de métricas de fluxo
+
+## Questionário de habilidades comunicativas
+
+Este repositório inclui um pequeno aplicativo Flask para registrar respostas de um questionário com escala de 1 a 5.
+
+### Como executar
+
+1. Instale as dependências:
+   ```bash
+   pip install flask
+   ```
+2. Inicie o servidor:
+   ```bash
+   python questionnaire_app/app.py
+   ```
+
+As respostas são armazenadas em `questionnaire_app/responses.csv`.

--- a/questionnaire_app/app.py
+++ b/questionnaire_app/app.py
@@ -1,0 +1,44 @@
+from flask import Flask, render_template, request, url_for
+import csv
+from datetime import datetime
+from pathlib import Path
+
+app = Flask(__name__)
+
+OPTIONS = {
+    "1": "Nunca ou raramente (de cada 10 situações reage dessa forma sem necessidade de ajuda no máximo 2 vezes)",
+    "2": "Com pouca frequência (de cada 10 situações desse tipo reage dessa forma sem necessidade de ajuda 3 a 4 vezes)",
+    "3": "Com regular frequência (de cada 10 situações reage dessa forma sem necessidade de ajuda 4 a 6 vezes)",
+    "4": "Muito frequentemente (de cada 10 situações reage dessa forma sem necessidade de ajuda 6 a 8 vezes)",
+    "5": "Sempre ou quase sempre (de cada 10 situações reage dessa forma sem necessidade de ajuda 8 a 10 vezes)",
+}
+
+QUESTIONS = [
+    "Olhar para o adulto quando chamada pelo nome",
+    "Manter contato pocular por pelo menos 1 segundo, quando chamada pelo nome",
+    "Olhar nos olhos de uma pessoa durante uma interação (aprox. 3 segundos)",
+    "Olhar nos olhos de uma pessoa durante 5 segundos",
+    "Olhar quando engajada numa brincadeira",
+    "Olhar à distância de 3 metros",
+    "Olhar à distância de 5 metros",
+    "Olhar à distancia de 5 metros e engajada numa brincadeira",
+    "Olhar para mais de uma pessoa (duas pessoas chamam a criança alternadamente)",
+    "Olhar para mais de uma pessoa alternadamente quando engajada em alguma brincadeira",
+]
+
+@app.route('/', methods=['GET', 'POST'])
+def questionnaire():
+    if request.method == 'POST':
+        responses = [request.form.get(f'q{i}', '') for i in range(1, len(QUESTIONS) + 1)]
+        filename = Path(__file__).with_name('responses.csv')
+        first_write = not filename.exists()
+        with filename.open('a', newline='', encoding='utf-8') as f:
+            writer = csv.writer(f)
+            if first_write:
+                writer.writerow(['timestamp'] + [f'q{i}' for i in range(1, len(QUESTIONS) + 1)])
+            writer.writerow([datetime.now().isoformat()] + responses)
+        return render_template('results.html', responses=responses, options=OPTIONS, questions=QUESTIONS)
+    return render_template('index.html', questions=QUESTIONS, options=OPTIONS)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/questionnaire_app/templates/index.html
+++ b/questionnaire_app/templates/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+    <meta charset="utf-8">
+    <title>Questionário - Contato Visual</title>
+</head>
+<body>
+    <h1>Desenvolvimento de habilidades comunicativas</h1>
+    <h2>Contato visual</h2>
+    <p><strong>Pontuação:</strong></p>
+    <ul>
+        <li>1. Nunca ou raramente (de cada 10 situações reage dessa forma sem necessidade de ajuda no máximo 2 vezes)</li>
+        <li>2. Com pouca frequência (de cada 10 situações desse tipo reage dessa forma sem
+            necessidade de ajuda 3 a 4 vezes)</li>
+        <li>3. Com regular frequência (de cada 10 situações reage dessa forma sem necessidade de ajuda 4 a 6 vezes)</li>
+        <li>4. Muito frequentemente (de cada 10 situações reage dessa forma sem necessidade de ajuda 6 a 8 vezes)</li>
+        <li>5. Sempre ou quase sempre (de cada 10 situações reage dessa forma sem necessidade de ajuda 8 a 10 vezes)</li>
+    </ul>
+    <form method="post">
+        {% for idx, question in enumerate(questions, start=1) %}
+            <fieldset>
+                <legend>{{ idx }}. {{ question }}</legend>
+                {% for value, description in options.items() %}
+                    <label>
+                        <input type="radio" name="q{{ idx }}" value="{{ value }}" required>
+                        {{ value }}
+                    </label>
+                {% endfor %}
+            </fieldset>
+            <br>
+        {% endfor %}
+        <button type="submit">Enviar</button>
+    </form>
+</body>
+</html>

--- a/questionnaire_app/templates/results.html
+++ b/questionnaire_app/templates/results.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+    <meta charset="utf-8">
+    <title>Respostas Registradas</title>
+</head>
+<body>
+    <h1>Respostas registradas</h1>
+    <ul>
+        {% for idx, question in enumerate(questions, start=1) %}
+            <li>{{ idx }}. {{ question }}: {{ responses[idx-1] }} - {{ options[responses[idx-1]] }}</li>
+        {% endfor %}
+    </ul>
+    <a href="{{ url_for('questionnaire') }}">Responder novamente</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create Flask app to capture communication skills questionnaire answers
- add HTML templates for questionnaire and results
- document how to run the app in README and ignore response data

## Testing
- `python -m py_compile questionnaire_app/app.py`
- `python -m pytest`
- `python questionnaire_app/app.py` *(terminated after launch)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a18c93e8832b8c07d1ae612a4d79